### PR TITLE
Update Jenkins_Installation.MD

### DIFF
--- a/Jenkins/Jenkins_Installation.MD
+++ b/Jenkins/Jenkins_Installation.MD
@@ -12,7 +12,7 @@ Jenkins is a self-contained Java-based program, ready to run out-of-the-box, wit
 1. We will be using open java for our demo, Get the latest version from http://openjdk.java.net/install/
    ```sh
    yum install java-1.8*
-   #yum -y install java-1.8.0-openjdk
+   #yum -y install java-1.8.0-openjdk-devel
    ```
 
 1. Confirm Java Version and set the java home


### PR DESCRIPTION
Wrong instruction: people should install JAVA SDK instead of JRE
Reference: https://www.digitalocean.com/community/tutorials/how-to-install-java-on-centos-and-fedora

To install OpenJDK 8 JRE using yum, run this command:
$sudo yum install java-1.8.0-openjdk

To install OpenJDK 8 JDK using yum, run this command:
$sudo yum install java-1.8.0-openjdk-devel