### PR TITLE
Java installation updated

### DIFF
--- a/Docker/tomcat_dockerfile
+++ b/Docker/tomcat_dockerfile
@@ -1,5 +1,8 @@
 FROM centos
-RUN yum install java -y
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum install -y java-1.8.0-openjdk
 RUN mkdir /opt/tomcat/
 WORKDIR /opt/tomcat
 ADD https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.54/bin/apache-tomcat-9.0.54.tar.gz /opt/tomcat
@@ -7,4 +10,3 @@ RUN tar xvfz apache*.tar.gz
 RUN mv apache-tomcat-9.0.54/* /opt/tomcat 
 EXPOSE 8080
 CMD ["/opt/tomcat/bin/catalina.sh", "run"]
-


### PR DESCRIPTION
"yum install -y java" is not working on EC2.
It works after replacing it with the below 4 lines:

RUN cd /etc/yum.repos.d/
RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
RUN yum install -y java-1.8.0-openjdk