### PR TITLE
created own docker file fixing java installation 

### DIFF
--- a/Docker/tomcat_dockerfile_mine
+++ b/Docker/tomcat_dockerfile_mine
@@ -1,0 +1,13 @@
+FROM centos:latest
+RUN mkdir /opt/tomcat
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN  dnf distro-sync -y
+RUN yum update -y
+RUN  yum install java -y
+WORKDIR /opt/tomcat
+ADD https://dlcdn.apache.org/tomcat/tomcat-10/v10.0.27/bin/apache-tomcat-10.0.27.tar.gz .
+RUN tar -xvzf apache-tomcat-10.0.27.tar.gz
+RUN mv apache-tomcat-10.0.27/* /opt/tomcat
+EXPOSE 8080
+CMD ["/opt/tomcat/bin/catalina.sh", "run"]


### PR DESCRIPTION
error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist The command '/bin/sh -c yum install java -y' returned a non-zero code: 1