### PR TITLE
docker image not updating

### DIFF
--- a/Kubernetes/regapp-deploy.yml
+++ b/Kubernetes/regapp-deploy.yml
@@ -18,6 +18,7 @@ spec:
     spec:
       containers:
       - name: regapp
+        # Update below image as per own dockerhub account e.g. abc/regapp
         image: valaxy/regapp
         imagePullPolicy: Always
         ports:


### PR DESCRIPTION
@yankils : I attended your course and did the hands on. On completion I found that my docker hub image was not getting picked by ansible. Reason for that in regapp-deploy.yml. You forgot to mention to point the image to the respective docker hub account. I struggled for hours for the issue and found the issue was that I was using valaxy/regapp which is pointing to your dockerhub account. So added comment for the same. Either update it in your course or point it in your file by some means