### PR TITLE
fixing Error: Failed to download metadata for repo 'appstream'

### DIFF
--- a/Docker/tomcat_dockerfile
+++ b/Docker/tomcat_dockerfile
@@ -1,4 +1,7 @@
 FROM centos
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum install java -y
 RUN mkdir /opt/tomcat/
 WORKDIR /opt/tomcat


### PR DESCRIPTION
fixing 
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist while running docker build .