### PR TITLE
fixing Error: Failed to download metadata for repo 'appstream' and up…

### DIFF
--- a/Docker/tomcat_dockerfile
+++ b/Docker/tomcat_dockerfile
@@ -1,10 +1,12 @@
 FROM centos
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN yum install java -y
 RUN mkdir /opt/tomcat/
 WORKDIR /opt/tomcat
-ADD https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.54/bin/apache-tomcat-9.0.54.tar.gz /opt/tomcat
+ADD https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.76/bin/apache-tomcat-9.0.76.tar.gz /opt/tomcat
 RUN tar xvfz apache*.tar.gz
-RUN mv apache-tomcat-9.0.54/* /opt/tomcat 
+RUN mv apache-tomcat-9.0.76/* /opt/tomcat
 EXPOSE 8080
 CMD ["/opt/tomcat/bin/catalina.sh", "run"]
-


### PR DESCRIPTION
fixing below errors

1. fixed version error (url not found)
2. fixed below error Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist